### PR TITLE
CRITICAL vulnerability: bump jackson-databind from 2.7.9 to 2.9.9.2

### DIFF
--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
-          <version>2.7.9</version>
+          <version>2.9.9.2</version>
         </dependency>
         <dependency>
           <groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
-          <version>2.7.9</version>
+          <version>2.9.9.2</version>
         </dependency>
         <dependency>
           <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
# Vulnerability Information

Bumps [jackson-databind](https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind/2.7.9) from 2.7.9 to 2.9.9.2.

Listed dependency **com.fasterxml.jackson.core:jackson-databind** contains vulnerable methods which are called from this project. This vulnerability appears to affect *jackson-databind* package versions lower than 2.9.9.2 (excluding). The vulnerability has been fixed in version 2.9.9.2, as can be seen from the linked CVE or package [release notes](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9) -
the micro-patch of 2.9.9.2 refers to the fix of this vulnerability.

| <center>Property</center> | <center>Value</center> |
|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
| <center> Linked CVE </center> | CVE-2019-14379                                                                                |
| <center> Number of affected methods </center> | 5                                                                                                                   |
| <center>Severity</center> | **CRITICAL**                                                                                                                                     |
| <center>Current version</center> | 2.7.9                                                                                                                                        |
| <center>Updated version</center> | 2.9.9.2                                                                                                                                    |
| <center>Backwards Compatibility</center> | True                                                                                                                         | 


# Vulnerable method calls

| Methods in this repository                                                    | Used package methods                                           | Origin vulnerable method                                          |
|----------|---------------------------------------|------------------------------------------------------------------------|
| [com.algorand.algosdk.v2.client.common/Utils.init()][1] | com.fasterxml.jackson.databind/ObjectMapper.reader() | com.fasterxml.jackson.databind.deser.std/<br>EnumSetDeserializer(JavaType enumType, JsonDeserializer<?> deser) |
| [com.algorand.algosdk.v2.client.common/Utils.init()][1] | com.fasterxml.jackson.databind/ObjectMapper.reader() | com.fasterxml.jackson.databind.deser/BasicDeserializerFactory.createMapDeserializer(DeserializationContext ctxt, MapType type, BeanDescription beanDesc) |
| [com.algorand.algosdk.util/Encoder.decodeFromMsgPack(String input, Class<T> tClass)][3] | com.fasterxml.jackson.databind/ObjectMapper.readValue(byte[] src, Class<T> valueType) | com.fasterxml.jackson.databind.deser.std/<br>EnumSetDeserializer(JavaType enumType, JsonDeserializer<?> deser) |
| [com.algorand.algosdk.util/Encoder.decodeFromMsgPack(String input, Class<T> tClass)][3] | com.fasterxml.jackson.databind/ObjectMapper.readValue(byte[] src, Class<T> valueType) | com.fasterxml.jackson.databind.deser/BasicDeserializerFactory.createMapDeserializer(DeserializationContext ctxt, MapType type, BeanDescription beanDesc) |
| [com.algorand.algosdk.util/Encoder.decodeFromJson(String input, Class<T> tClass)][3] | com.fasterxml.jackson.databind/ObjectReader.readValue(String src) | com.fasterxml.jackson.databind.deser.std/<br>EnumSetDeserializer(JavaType enumType, JsonDeserializer<?> deser) |
| [com.algorand.algosdk.util/Encoder.decodeFromJson(String input, Class<T> tClass)][3] | com.fasterxml.jackson.databind/ObjectReader.readValue(String src) | com.fasterxml.jackson.databind.deser/BasicDeserializerFactory.createMapDeserializer(DeserializationContext ctxt, MapType type, BeanDescription beanDesc) |
| [com.algorand.algosdk.v2.client.common/Response.convertMessagePack()][4] | com.fasterxml.jackson.databind/ObjectReader.readValue(byte[] src) | com.fasterxml.jackson.databind.deser.std/<br>EnumSetDeserializer(JavaType enumType, JsonDeserializer<?> deser) |
| [com.algorand.algosdk.v2.client.common/Response.convertMessagePack()][4] | com.fasterxml.jackson.databind/ObjectReader.readValue(byte[] src) | com.fasterxml.jackson.databind.deser/BasicDeserializerFactory.createMapDeserializer(DeserializationContext ctxt, MapType type, BeanDescription beanDesc) |
| [com.algorand.algosdk.v2.client.common/Response.convertMessagePack()][5] | com.fasterxml.jackson.databind/ObjectReader.forType(Class<?> valueType) | com.fasterxml.jackson.databind.deser.std/<br>EnumSetDeserializer(JavaType enumType, JsonDeserializer<?> deser) |
| [com.algorand.algosdk.v2.client.common/Response.convertMessagePack()][5] | com.fasterxml.jackson.databind/ObjectReader.forType(Class<?> valueType) | com.fasterxml.jackson.databind.deser/BasicDeserializerFactory.createMapDeserializer(DeserializationContext ctxt, MapType type, BeanDescription beanDesc) |
| [com.algorand.algosdk.v2.client.common/Response.convertJson()][6] | com.fasterxml.jackson.databind/ObjectReader.readValue(byte[] src) | com.fasterxml.jackson.databind.deser.std/<br>EnumSetDeserializer(JavaType enumType, JsonDeserializer<?> deser) |
| [com.algorand.algosdk.v2.client.common/Response.convertJson()][6] | com.fasterxml.jackson.databind/ObjectReader.readValue(byte[] src) | com.fasterxml.jackson.databind.deser/BasicDeserializerFactory.createMapDeserializer(DeserializationContext ctxt, MapType type, BeanDescription beanDesc) |
| [com.algorand.algosdk.v2.client.common/Response.convertJson()][7] | com.fasterxml.jackson.databind/ObjectReader.forType(Class<?> valueType) | com.fasterxml.jackson.databind.deser.std/<br>EnumSetDeserializer(JavaType enumType, JsonDeserializer<?> deser) |
| [com.algorand.algosdk.v2.client.common/Response.convertJson()][7] | com.fasterxml.jackson.databind/ObjectReader.forType(Class<?> valueType) | com.fasterxml.jackson.databind.deser/BasicDeserializerFactory.createMapDeserializer(DeserializationContext ctxt, MapType type, BeanDescription beanDesc) |


[1]: https://github.com/algorand/java-algorand-sdk/blob/34b27834770e8cc18240b78589f8d7c7ebce215f/src/main/java/com/algorand/algosdk/v2/client/common/Utils.java#L19
[2]: https://github.com/algorand/java-algorand-sdk/blob/34b27834770e8cc18240b78589f8d7c7ebce215f/src/main/java/com/algorand/algosdk/util/Encoder.java#L60
[3]: https://github.com/algorand/java-algorand-sdk/blob/34b27834770e8cc18240b78589f8d7c7ebce215f/src/main/java/com/algorand/algosdk/util/Encoder.java#L72
[4]: https://github.com/algorand/java-algorand-sdk/blob/34b27834770e8cc18240b78589f8d7c7ebce215f/src/main/java/com/algorand/algosdk/v2/client/common/Response.java#L69
[5]: https://github.com/algorand/java-algorand-sdk/blob/34b27834770e8cc18240b78589f8d7c7ebce215f/src/main/java/com/algorand/algosdk/v2/client/common/Response.java#L69
[6]: https://github.com/algorand/java-algorand-sdk/blob/34b27834770e8cc18240b78589f8d7c7ebce215f/src/main/java/com/algorand/algosdk/v2/client/common/Response.java#L65
[7]: https://github.com/algorand/java-algorand-sdk/blob/34b27834770e8cc18240b78589f8d7c7ebce215f/src/main/java/com/algorand/algosdk/v2/client/common/Response.java#L65

### What do the columns represent?
The 1st column in the table indicates the method in this repository that was found to be affected by vulnerable methods from the *jackson-databind* package.

The 2nd column indicates the *jackson-databind* method that was directly called from this repository.


The 3rd column indicates the origin vulnerable method in the *jackson-databind* package. According to our dataset, this is one of the methods that produces the **CVE-2019-14379** vulnerability. This method was found to be internally chain-called in the *jackson-databind* package by the method listed in column 2.


### How were the results generated?
This vulnerability was analyzed specifically for usage in this project using the [FASTEN Project](https://www.fasten-project.eu/view/Main/). Statical method-level analysis was used to check for usage of vulnerable methods in the project.

Method calls between your project and *jackson-databind* have been mapped using a directed graph. From this graph, it could be then be seen whether any vulnerable *jackson-databind* methods are being called from within your project.

# Research Scope

We are a [team](https://github.com/orgs/TU-Delft-Research-Group-2021/people) of 3 BSc Computer Science students at the TU Delft. Our goal is to conduct research on how developers react to method-level vulnerability information that affects their projects. We would highly appreciate if you could help us with our research and please tick statements which apply to you below.

### First impression checklist
- [ ] I have read this pull request description.
- [ ] I was aware of this dependency vulnerability affecting my project before being informed by this Pull Request.
- [ ] I was convinced by the provided method information that this vulnerability indeed affects my project.
- [ ] After seeing the provided method-level information, I plan on fixing the vulnerability.

### After fixing vulnerability checklist
- [ ] I found that the provided method information has made my process of dealing with the vulnerable dependency easier.
- [ ] I have given priority to the task of fixing the vulnerability over other project tasks that are yet to be completed.
- [ ] I would like to receive this kind of method information in future vulnerable dependency Pull Request descriptions.

<img align="right" src="https://user-images.githubusercontent.com/52587121/119507191-e6226c80-bd6e-11eb-8c2a-306309777e0f.png" hspace="20" width="150"/>